### PR TITLE
re-enable selection of sim extensions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
     "**/.factorypath": true,
     "**/*~": true
   },
-  "wpilib.skipSelectSimulateExtension": true,
+  "wpilib.skipSelectSimulateExtension": false,
   "java.test.config": [
     {
       "name": "WPIlibUnitTests",


### PR DESCRIPTION
This change enables the following dialog to allow you to use the FRC Driver Station when simulating the ROMI

![image](https://github.com/DevilBotz2876/RomiTutorial2023/assets/49494444/ee050c39-cdf9-4883-91b4-6b03fe4ed779)
